### PR TITLE
Fix logic for "for...in/of" loops

### DIFF
--- a/lib/loop-protect.js
+++ b/lib/loop-protect.js
@@ -26,15 +26,16 @@ function protect(src, protectFn) {
     }
     src[node.start] = str
   }
-  
+
   function loopStatement(node) {
+    var line = (node.test || node.left).loc.start.line;
     if (node.body.type === 'BlockStatement') {
       var src = source(node.body).split('{');
-      src[1] = protectFn + '(' + node.test.loc.start.line + ');' + src[1];
+      src[1] = protectFn + '(' + line + ');' + src[1];
       src = src.join('{');
       replace(node.body, src);
     } else {
-      replace(node.body, '{' + protectFn + '(' + node.test.loc.start.line + ');' + source(node.body) + '}');
+      replace(node.body, '{' + protectFn + '(' + line + ');' + source(node.body) + '}');
     }
   }
   function callExpression(node) {
@@ -52,6 +53,6 @@ function protect(src, protectFn) {
     NewExpression: callExpression,
     TaggedTemplateExpression: callExpression
   });
-  
+
   return src.join('');
 }

--- a/test/halting/for-in.js
+++ b/test/halting/for-in.js
@@ -1,0 +1,4 @@
+var obj = {foo: 42, bar: 42};
+for (var prop in obj) {
+}
+for (var prop in obj);


### PR DESCRIPTION
The code currently throws the error

```
TypeError: Cannot read property 'loc' of undefined
```

That's because `for...in/of` loops don't have a `test` property (http://astexplorer.net/#/CUhuGjRDKX), but have `left` and `right` instead. It seems the line number is only used for error reporting so this fix simply uses `node.test` if it exists, otherwise `node.left`.

Added a simple test with a `for...in` loop just to verify that it is transformed without error.

Test are passing.

See also https://github.com/fkling/astexplorer/issues/86
