### PR TITLE
Fix CallExpressions in statement position (fixes #2)

### DIFF
--- a/lib/loop-protect.js
+++ b/lib/loop-protect.js
@@ -38,11 +38,20 @@ function protect(src, protectFn) {
       replace(node.body, '{' + protectFn + '(' + line + ');' + source(node.body) + '}');
     }
   }
-  function callExpression(node) {
-    replace(node, '(' + protectFn + '(' + node.loc.start.line + '),' + source(node) + ')');
+  function callExpression(node, ancestors) {
+    var replacement =
+      '(' + protectFn + '(' + node.loc.start.line + '),' + source(node) + ')';
+
+    // The following check is needed to prevent the added wrapping parenthesis
+    // from being interpreted as a function call.
+    if (ancestors[ancestors.length - 2].type === 'ExpressionStatement') {
+      replacement = ';' + replacement;
+    }
+
+    replace(node, replacement);
   }
 
-  walk.simple(ast, {
+  walk.ancestor(ast, {
     WhileStatement: loopStatement,
     DoWhileStatement: loopStatement,
     ForStatement: loopStatement,


### PR DESCRIPTION
This prefixes the replacement code with a `;` if the CallExpression is the child of a StatementExpression, to prevent the grouping operator from being interpreted as a function call.

Not sure if the use of `ancestor` instead of `simple` adds any significant performance overhead.

I didn't add any tests for this since I wasn't sure how to integrate this with your test setup. However, `npm test` passes.
