### PR TITLE
acorn: 2 -> 7

### DIFF
--- a/lib/halting-problem.js
+++ b/lib/halting-problem.js
@@ -1,12 +1,12 @@
 'use strict';
 
 var acorn = require('acorn');
-var walk = require('acorn/dist/walk');
+var walk = require('acorn-walk');
 
 module.exports = halts;
 function halts(src) {
   var ast = typeof src === 'string' ? acorn.parse(src, {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     allowReturnOutsideFunction: true,
     allowImportExportEverywhere: true,
     allowHashBang: true,
@@ -96,6 +96,7 @@ function halts(src) {
         }
       }
     }
+    debugger;
   walk.recursive(ast, {}, {
     WhileStatement: whileStatement,
     DoWhileStatement: whileStatement,
@@ -144,7 +145,7 @@ function halts(src) {
       var breakLabelsBefore = breakLabels;
       var hasThrowBefore = hasThrow;
       var hasReturnOrYieldBefore = hasReturnOrYield;
-      c(node.body, st, "ScopeBody");
+      c(node.body, st, "Statement");
       hasBreak = hasBreakBefore;
       breakLabels = breakLabelsBefore;
       hasThrow = hasThrowBefore;
@@ -154,7 +155,7 @@ function halts(src) {
       var hasThrowBefore = hasThrow;
       c(node.block, st, "Statement");
       hasThrow = hasThrowBefore;
-      if (node.handler) c(node.handler.body, st, "ScopeBody");
+      if (node.handler) c(node.handler.body, st, "Statement");
       if (node.finalizer) c(node.finalizer, st, "Statement");
     }
   });

--- a/lib/halting-problem.js
+++ b/lib/halting-problem.js
@@ -96,7 +96,6 @@ function halts(src) {
         }
       }
     }
-    debugger;
   walk.recursive(ast, {}, {
     WhileStatement: whileStatement,
     DoWhileStatement: whileStatement,

--- a/lib/loop-protect.js
+++ b/lib/loop-protect.js
@@ -3,13 +3,13 @@
 // inspired by https://github.com/jsbin/loop-protect
 
 var acorn = require('acorn');
-var walk = require('acorn/dist/walk');
+var walk = require('acorn-walk');
 
 module.exports = protect;
 function protect(src, protectFn) {
   protectFn = protectFn || 'haltingProblem.protect';
   var ast = acorn.parse(src, {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     allowReturnOutsideFunction: true,
     allowImportExportEverywhere: true,
     allowHashBang: true,

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "Solves the halting problem :)",
   "keywords": [],
   "dependencies": {
-    "acorn": "^2.4.0"
+    "acorn": "^7.0.0",
+    "acorn-walk": "^7.0.0"
   },
   "devDependencies": {
-    "testit": "^2.0.2"
+    "testit": "^3.1.0"
   },
   "scripts": {
     "test": "node test"


### PR DESCRIPTION
Thank you, for such a great library :).

Updated dependencies, changed `ScopeBody` to `Statement`, as it [doesn't exist anymore](https://github.com/acornjs/acorn/blob/master/acorn-walk/CHANGELOG.md#600-2018-09-14).

All tests are passing.